### PR TITLE
fix: replace depricated async-std with smol

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install clippy
         run: rustup component add clippy
       - run: cargo clippy -- --deny warnings
-      - run: cargo clippy --no-default-features --features async-std -- --deny warnings
+      - run: cargo clippy --no-default-features --features smol -- --deny warnings
       - run: cargo clippy -p http-cache-stream-reqwest -- --deny warnings
 
   test:
@@ -50,8 +50,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Test for tokio feature
         run: cargo test --no-default-features --features tokio
-      - name: Test for async-std feature
-        run: cargo test --no-default-features --features async-std
+      - name: Test for smol feature
+        run: cargo test --no-default-features --features smol
       - name: Test for reqwest
         run: cargo test -p http-cache-stream-reqwest
 
@@ -75,8 +75,8 @@ jobs:
         run: cargo binstall -y --version 0.16.0-beta.23 cargo-msrv
       - name: Verify MSRV (tokio)
         run: cargo msrv verify --output-format minimal --no-default-features --features tokio
-      - name: Verify MSRV (async-std)
-        run: cargo msrv verify --output-format minimal --no-default-features --features async-std
+      - name: Verify MSRV (smol)
+        run: cargo msrv verify --output-format minimal --no-default-features --features smol
       - name: Verify MSRV for reqwest
         working-directory: ./crates/reqwest
         run: cargo msrv verify --output-format minimal

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ reqwest = { version = "0.12.14", default-features = false }
 reqwest-middleware = "0.4.1"
 blake3 = "1.6.1"
 tempfile = "3.18.0"
-smol= "2.0.2"
+smol = "2.0.2"
 
 [package]
 name = "http-cache-stream"
@@ -68,7 +68,7 @@ pin-project-lite = { workspace = true }
 cfg-if = {workspace = true }
 blake3 = { workspace = true }
 tempfile = { workspace = true }
-smol = {workspace = true, optional = true}
+smol = { workspace = true, optional = true }
 
 [features]
 default = ["tokio"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ bincode = { version = "2.0.0", features = ["serde"] }
 tracing = "0.1.41"
 tokio = { version = "1.44.0", default-features = false, features = ["fs", "io-util", "rt"] }
 tokio-util = { version = "0.7.13", features = ["io"] }
-async-std = "1.13.0"
 http-body = "1.0.1"
 bytes = "1.10.1"
 pin-project-lite = "0.2.16"
@@ -35,6 +34,7 @@ reqwest = { version = "0.12.14", default-features = false }
 reqwest-middleware = "0.4.1"
 blake3 = "1.6.1"
 tempfile = "3.18.0"
+smol= "2.0.2"
 
 [package]
 name = "http-cache-stream"
@@ -62,18 +62,19 @@ bincode = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true, optional = true }
 tokio-util = { workspace = true, optional = true }
-async-std = { workspace = true, optional = true }
 http-body = { workspace = true }
 bytes = { workspace = true }
 pin-project-lite = { workspace = true }
 cfg-if = {workspace = true }
 blake3 = { workspace = true }
 tempfile = { workspace = true }
+smol = {workspace = true, optional = true}
 
 [features]
 default = ["tokio"]
 tokio = ["dep:tokio", "dep:tokio-util"]
-async-std = ["dep:async-std"]
+smol = ["dep:smol"]
+
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.59"

--- a/crates/reqwest/src/lib.rs
+++ b/crates/reqwest/src/lib.rs
@@ -69,10 +69,7 @@ impl http_cache_stream::http_body::Body for MiddlewareBody {
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<Frame<Bytes>, Self::Error>>> {
         // The two body implementations differ on error type, so map it here
-        self.project()
-            .body
-            .poll_frame(cx)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+        self.project().body.poll_frame(cx).map_err(io::Error::other)
     }
 }
 

--- a/src/body.rs
+++ b/src/body.rs
@@ -146,14 +146,14 @@ impl<B: HttpBody> Body<B> {
                 let mut reader = tokio_util::io::StreamReader::new(&mut stream);
                 tokio::io::copy(&mut reader, file).await?;
                 Ok(hex::encode(stream.hash().as_bytes()))
-            } else if #[cfg(feature = "async-std")] {
+            } else if #[cfg(feature = "smol")] {
                 use futures::stream::TryStreamExt;
                 let this = self;
                 futures::pin_mut!(this);
 
                 let mut stream = HashStream::new(this);
                 let mut reader = (&mut stream).into_async_read();
-                async_std::io::copy(&mut reader, file).await?;
+                smol::io::copy(&mut reader, file).await?;
                 Ok(hex::encode(stream.hash().as_bytes()))
             } else {
                 unimplemented!()
@@ -203,7 +203,7 @@ impl<B: HttpBody> http_body::Body for Body<B> {
                                 Poll::Ready(Some(Ok(Frame::data(chunk.freeze()))))
                             }
                         }
-                    } else if #[cfg(feature = "async-std")] {
+                    } else if #[cfg(feature = "smol")] {
                         use futures::AsyncRead;
                         use bytes::BufMut;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 mod body;
 mod cache;
 pub mod lock;
-pub(crate) mod runtime;
+pub mod runtime;
 pub mod storage;
 
 pub use body::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 mod body;
 mod cache;
 pub mod lock;
-pub mod runtime;
+pub(crate) mod runtime;
 pub mod storage;
 
 pub use body::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! By default, this crate uses `tokio` as its async runtime.
 //!
-//! Enable the `async-std` feature for using the `async-std` runtime instead.
+//! Enable the `smol` feature for using the `smol` runtime instead.
 
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -178,9 +178,6 @@ async fn lock(file: File, path: &Path, access: Access) -> io::Result<LockedFile>
         .await,
     ) {
         Some(res) => res,
-        None => Err(io::Error::new(
-            io::ErrorKind::Other,
-            "failed to wait for file lock",
-        )),
+        None => Err(io::Error::other("failed to wait for file lock")),
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,10 +1,10 @@
 //! Implementation of the async runtime integration.
 
-#[cfg(not(any(feature = "tokio", feature = "async-std")))]
-compile_error!("either feature `tokio` or `async-std` must be enabled");
+#[cfg(not(any(feature = "tokio", feature = "smol")))]
+compile_error!("either feature `tokio` or `smol` must be enabled");
 
-#[cfg(all(feature = "tokio", feature = "async-std"))]
-compile_error!("features `tokio` and `async-std` are mutually exclusive");
+#[cfg(all(feature = "tokio", feature = "smol"))]
+compile_error!("features `tokio` and `smol` are mutually exclusive");
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "tokio")] {
@@ -15,9 +15,9 @@ cfg_if::cfg_if! {
         pub fn unwrap_task_output<T>(result: Result<T, tokio::task::JoinError>) -> Option<T> {
             result.ok()
         }
-    } else if #[cfg(feature = "async-std")] {
-        pub use async_std::fs::File;
-        pub use async_std::task::spawn_blocking;
+    } else if #[cfg(feature = "smol")] {
+        pub use smol::fs::File;
+        pub use smol::unblock as spawn_blocking;
 
         /// Helper for difference in `spawn_blocking` signatures.
         pub fn unwrap_task_output<T>(result: T) -> Option<T> {


### PR DESCRIPTION
This PR implements the `smol`  runtime replacing the `async-std` because it's [depricated](https://github.com/async-rs/async-std?tab=readme-ov-file#async-std-has-been-discontinued-use-smol-instead)

**Some changes:**
- Replaced `async-std` with `smol` and included alias name `spawn_blocking`  for `smol::unblock`.
- replacing closure with function itself `io::Error::other(e)`.

**Test Pass:**
- [☑️] cargo test
- [☑️] cargo test -p http-cache-stream-reqwest
- [☑️] cargo clippy --all
- [☑️] cargo +nightly fmt --check
- [☑️] cargo doc

**Related Issue:**
#8 