### PR TITLE
fix: fix error encountered with Azure Storage.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,41 +1,3 @@
-[workspace]
-resolver = "2"
-members = [
-    "crates/reqwest",
-]
-
-[workspace.package]
-license = "MIT OR Apache-2.0"
-edition = "2024"
-authors = ["The St. Jude Rust Labs project developers"]
-homepage = "https://github.com/stjude-rust-labs/http-cache-stream"
-repository = "https://github.com/stjude-rust-labs/http-cache-stream"
-
-[workspace.dependencies]
-http = "1.2.0"
-http-cache-semantics = "2.1.0"
-serde = { version = "1.0.218", features = ["derive"] }
-http-serde = "2.1.1"
-httpdate = "1.0.3"
-futures = "0.3.31"
-anyhow = "1.0.97"
-libc = "0.2.170"
-sha2 = "0.10.8"
-hex = "0.4.3"
-bincode = { version = "2.0.0", features = ["serde"] }
-tracing = "0.1.41"
-tokio = { version = "1.44.0", default-features = false, features = ["fs", "io-util", "rt"] }
-tokio-util = { version = "0.7.13", features = ["io"] }
-http-body = "1.0.1"
-bytes = "1.10.1"
-pin-project-lite = "0.2.16"
-cfg-if = "1.0.0"
-reqwest = { version = "0.12.14", default-features = false }
-reqwest-middleware = "0.4.1"
-blake3 = "1.6.1"
-tempfile = "3.18.0"
-smol = "2.0.2"
-
 [package]
 name = "http-cache-stream"
 version = "0.1.0"
@@ -46,43 +8,78 @@ license = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }
+[workspace]
+resolver = "2"
+members = ["crates/reqwest"]
 
-[dependencies]
-http = { workspace = true }
-http-cache-semantics = { workspace = true }
-serde = { workspace = true }
-http-serde = { workspace = true }
-httpdate = { workspace = true }
-futures = { workspace = true }
-anyhow = { workspace = true }
-libc = { workspace = true }
-sha2 = { workspace = true }
-hex = { workspace = true }
-bincode = { workspace = true }
-tracing = { workspace = true }
-tokio = { workspace = true, optional = true }
-tokio-util = { workspace = true, optional = true }
-http-body = { workspace = true }
-bytes = { workspace = true }
-pin-project-lite = { workspace = true }
-cfg-if = {workspace = true }
-blake3 = { workspace = true }
-tempfile = { workspace = true }
-smol = { workspace = true, optional = true }
+[workspace.package]
+license = "MIT OR Apache-2.0"
+edition = "2024"
+authors = ["The St. Jude Rust Labs project developers"]
+homepage = "https://github.com/stjude-rust-labs/http-cache-stream"
+repository = "https://github.com/stjude-rust-labs/http-cache-stream"
+
+[workspace.dependencies]
+anyhow = "1.0.98"
+bincode = { version = "2.0.1", features = ["serde"] }
+blake3 = "1.8.2"
+bytes = "1.10.1"
+cfg-if = "1.0.1"
+futures = "0.3.31"
+hex = "0.4.3"
+http = "1.3.1"
+http-body = "1.0.1"
+http-cache-semantics = "2.1.0"
+http-serde = "2.1.1"
+httpdate = "1.0.3"
+libc = "0.2.175"
+pin-project-lite = "0.2.16"
+reqwest = { version = "0.12.22", default-features = false }
+reqwest-middleware = "0.4.2"
+serde = { version = "1.0.219", features = ["derive"] }
+sha2 = "0.10.9"
+smol = "2.0.2"
+tempfile = "3.20.0"
+tokio = { version = "1.47.1", default-features = false, features = ["fs", "io-util", "rt"] }
+tokio-util = { version = "0.7.16", features = ["io"] }
+tracing = "0.1.41"
 
 [features]
 default = ["tokio"]
 tokio = ["dep:tokio", "dep:tokio-util"]
 smol = ["dep:smol"]
 
+[dependencies]
+anyhow = { workspace = true }
+bincode = { workspace = true }
+blake3 = { workspace = true }
+bytes = { workspace = true }
+cfg-if = { workspace = true }
+futures = { workspace = true }
+hex = { workspace = true }
+http = { workspace = true }
+http-body = { workspace = true }
+http-cache-semantics = { workspace = true }
+http-serde = { workspace = true }
+httpdate = { workspace = true }
+libc = { workspace = true }
+pin-project-lite = { workspace = true }
+serde = { workspace = true }
+sha2 = { workspace = true }
+smol = { workspace = true, optional = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, optional = true }
+tokio-util = { workspace = true, optional = true }
+tracing = { workspace = true }
+
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.59"
+version = "0.60"
 features = [
-  "Win32_Foundation",
-  "Win32_Storage",
-  "Win32_Storage_FileSystem",
-  "Win32_System",
-  "Win32_System_IO",
-  "Win32_Security",
-  "Win32_System_Console",
+    "Win32_Foundation",
+    "Win32_Storage",
+    "Win32_Storage_FileSystem",
+    "Win32_System",
+    "Win32_System_IO",
+    "Win32_Security",
+    "Win32_System_Console",
 ]


### PR DESCRIPTION
This PR fixes the handling of a 304 response where the server is not responding with the correct headers (e.g. Azure Storage).

A 304 response for a resource should have the same headers as a 200 response for the same resource; when those headers are missing, we error saying that the server said it was unmodified, but the cache says the body needs updating.

Instead of returning an error, we now serve up the stale cached body as the server says it was unmodified. However, as we don't update the stored policy object, a future request for the same resource will always preform revalidation until the server responds with a 200 or a correctly implemented 304.

This PR includes an update to the dependencies and a reformatting of `Cargo.toml` based on `cargo sort`.