### PR TITLE
fix: add back `x-cache-digest` header.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ futures = "0.3.31"
 hex = "0.4.3"
 http = "1.3.1"
 http-body = "1.0.1"
-http-cache-semantics = { version = "2.1.0", git = "https://github.com/peterhuene/rusty-http-cache-semantics", branch = "allow-partial-content" }
+http-cache-semantics = "2.1.0"
 http-serde = "2.1.1"
 httpdate = "1.0.3"
 libc = "0.2.175"

--- a/crates/reqwest/src/lib.rs
+++ b/crates/reqwest/src/lib.rs
@@ -38,6 +38,7 @@ use bytes::Bytes;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 pub use http_cache_stream::X_CACHE;
+pub use http_cache_stream::X_CACHE_DIGEST;
 pub use http_cache_stream::X_CACHE_LOOKUP;
 use http_cache_stream::http::Extensions;
 use http_cache_stream::http::Uri;


### PR DESCRIPTION
The previous PR removed the `x-cache-digest` header in all responses.

It _should_ have limited the removal to just the times when the cached body isn't being served from the cache. The other instances where we are serving the body from the cache can set the header.

Additionally, this updates the `http-cache-semantics` dependency to go back to the upstream crate that doesn't support 206 responses.

Given the complexity and narrow scope of supporting very specific ranged requests, it wasn't worth the trouble of implementing it.