### PR TITLE
feat: add a "revalidation hook" to `Cache` to allow for recalculation of authentication.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Added
+
+* Added `with_revalidation_hook` to allow for modifying revalidation request
+  headers ([#15](https://github.com/stjude-rust-labs/http-cache-stream/pull/15)).
+
 ## 0.2.0 - 08-15-2025
 
 #### Changed

--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@
   </p>
 </p>
 
-## Getting started
+## Overview
 
-TODO: complete this section
+The `http-cache-stream` crate can be used to cache responses in accordance with
+HTTP caching semantics.
 
-## How this crate differs from [`http-cache`][http-cache]
+### How this crate differs from [`http-cache`][http-cache]
 
 The [`http-cache`][http-cache] crate is a highly-configurable HTTP cache that
 supports different storage backends and middleware for many popular Rust HTTP
@@ -49,7 +50,7 @@ The `http-cache-stream` crate is inspired by the implementation provided by
   cached bodies, but does provide some fault tolerance for writes to cache
   storage (i.e. partially written cache entries are discarded).
 * The API for `http-cache-stream` is not nearly as configurable as `http-cache`.
-* Only a middleware implementation for `reqwest` will be made initially.
+* Currently only supports a middleware implementation for `reqwest`.
 
 ## Development
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -291,12 +291,31 @@ impl http_cache_semantics::RequestLike for RequestLike {
     }
 }
 
+/// Represents a revalidation hook.
+///
+/// The hook is provided the original request and a mutable header map
+/// containing headers explicitly set for the revalidation request.
+///
+/// For example, a hook may alter the revalidation headers to update an
+/// `Authorization` header based on the headers used for revalidation.
+///
+/// If the hook returns an error, the error is propagated out as the result of
+/// the original request.
+type RevalidationHook = dyn Fn(&dyn http_cache_semantics::RequestLike, &mut HeaderMap) -> Result<()>
+    + Send
+    + Sync
+    + 'static;
+
 /// Implement a HTTP cache.
 pub struct Cache<S> {
     /// The cache storage.
     storage: S,
     /// The cache options to use.
     options: CacheOptions,
+    /// Stores the revalidation hook.
+    ///
+    /// This is `None` if no revalidation hook is used.
+    hook: Option<Box<RevalidationHook>>,
 }
 
 impl<S> Cache<S>
@@ -314,12 +333,38 @@ where
                 shared: false,
                 ..Default::default()
             },
+            hook: None,
         }
     }
 
     /// Construct a new cache with the given storage and options.
     pub fn new_with_options(storage: S, options: CacheOptions) -> Self {
-        Self { storage, options }
+        Self {
+            storage,
+            options,
+            hook: None,
+        }
+    }
+
+    /// Sets the revalidation hook to use.
+    ///
+    /// The hook is provided the original request and a mutable header map
+    /// containing headers explicitly set for the revalidation request.
+    ///
+    /// For example, a hook may alter the revalidation headers to update an
+    /// `Authorization` header based on the headers used for revalidation.
+    ///
+    /// If the hook returns an error, the error is propagated out as the result
+    /// of the original request.
+    pub fn with_revalidation_hook(
+        mut self,
+        hook: impl Fn(&dyn http_cache_semantics::RequestLike, &mut HeaderMap) -> Result<()>
+        + Send
+        + Sync
+        + 'static,
+    ) -> Self {
+        self.hook = Some(Box::new(hook));
+        self
     }
 
     /// Gets the storage used by the cache.
@@ -469,7 +514,7 @@ where
     ) -> Result<Response<Body<B>>> {
         let request_like = RequestLike::new(&request);
 
-        let headers = match stored
+        let mut headers = match stored
             .policy
             .before_request(&request_like, SystemTime::now())
         {
@@ -510,6 +555,13 @@ where
             key,
             "response is stale: sending request upstream for validation"
         );
+
+        // Invoke the revalidation hook if the request will use different headers
+        if let Some(headers) = &mut headers
+            && let Some(hook) = &self.hook
+        {
+            hook(&request_like, headers)?;
+        }
 
         // Revalidate the request
         match request.send(headers).await {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -553,7 +553,7 @@ where
             authority = request_like.uri.authority().map(Authority::as_str),
             path = request_like.uri.path(),
             key,
-            "response is stale: sending request upstream for validation"
+            "response is stale: sending request upstream for revalidation"
         );
 
         // Invoke the revalidation hook if the request will use different headers


### PR DESCRIPTION
This PR adds a `with_revalidation_hook` method to `Cache` that allows users to control the headers sent as part of a cache revalidation request.

This is needed for Azure Storage where they inexplicably use conditional request headers like `If-None-Match` as part of the authentication signature, which breaks transparent caching middleware like this one.

With the hook, a new `Authorization` header can be calculated and then overridden for the request to revalidate.