### PR TITLE
chore: update dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,30 +21,30 @@ repository = "https://github.com/stjude-rust-labs/http-cache-stream"
 rust-version = "1.89.0"
 
 [workspace.dependencies]
-anyhow = "1.0.98"
-bincode = { version = "2.0.1", features = ["serde"] }
-blake3 = "1.8.2"
-bytes = "1.10.1"
-cfg-if = "1.0.1"
+anyhow = "1.0.100"
+bincode = "1.3.3"
+blake3 = "1.8.3"
+bytes = "1.11.1"
+cfg-if = "1.0.4"
 futures = "0.3.31"
 hex = "0.4.3"
-http = "1.3.1"
+http = "1.4.0"
 http-body = "1.0.1"
 http-body-util = "0.1.3"
-http-cache-semantics = "2.1.0"
+http-cache-semantics = "3.0.0"
 http-serde = "2.1.1"
 httpdate = "1.0.3"
-libc = "0.2.175"
+libc = "0.2.180"
 pin-project-lite = "0.2.16"
-reqwest = { version = "0.12.22", default-features = false }
-reqwest-middleware = "0.4.2"
-serde = { version = "1.0.219", features = ["derive"] }
+reqwest = { version = "0.13.1", default-features = false }
+reqwest-middleware = "0.5.0"
+serde = { version = "1.0.228", features = ["derive"] }
 sha2 = "0.10.9"
 smol = "2.0.2"
-tempfile = "3.20.0"
-tokio = { version = "1.47.1", default-features = false, features = ["fs", "io-util", "rt", "macros"] }
-tokio-util = { version = "0.7.16", features = ["io"] }
-tracing = "0.1.41"
+tempfile = "3.24.0"
+tokio = { version = "1.49.0", default-features = false, features = ["fs", "io-util", "rt", "macros"] }
+tokio-util = { version = "0.7.18", features = ["io"] }
+tracing = "0.1.44"
 
 [features]
 default = ["tokio"]

--- a/src/storage/default.rs
+++ b/src/storage/default.rs
@@ -358,11 +358,7 @@ impl DefaultCacheStorageInner {
         };
 
         // Decode the cached response
-        Ok(
-            bincode::serde::decode_from_std_read::<CachedResponse, _, _>(
-                &mut response,
-                bincode::config::standard(),
-            )
+        Ok(bincode::deserialize_from(&mut response)
             .inspect_err(|e| {
                 debug!(
                     "failed to deserialize response file `{path}`: {e} (cache entry will be \
@@ -370,8 +366,7 @@ impl DefaultCacheStorageInner {
                     path = self.response_path(key).display()
                 );
             })
-            .ok(),
-        )
+            .ok())
     }
 
     /// Writes a response to storage for the given key.
@@ -382,7 +377,7 @@ impl DefaultCacheStorageInner {
         let mut file = self.lock_response_exclusive(key).await?;
 
         // Encode the response
-        bincode::serde::encode_into_std_write(response, &mut file, bincode::config::standard())
+        bincode::serialize_into(&mut file, &response)
             .with_context(|| format!("failed to serialize response data for cache key `{key}`"))
             .map(|_| ())
     }


### PR DESCRIPTION
This PR updates dependencies to latest.

The exception to this is the `bincode` dependency. The `bincode` project is no longer being actively developed. The maintainers have indicated that version `1.3.3` is considered to be complete and will only receive updates for CVEs.

After investigating alternatives to `bincode`, I decided to keep the `bincode` dependency but downgrade it to the suggested "complete" version.