### PR TITLE
fix: remove content digesting.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ rust-version = "1.89.0"
 [workspace.dependencies]
 anyhow = "1.0.100"
 bincode = "1.3.3"
-blake3 = "1.8.3"
 bytes = "1.11.1"
 cfg-if = "1.0.4"
 futures = "0.3.31"
@@ -54,7 +53,6 @@ smol = ["dep:smol"]
 [dependencies]
 anyhow = { workspace = true }
 bincode = { workspace = true }
-blake3 = { workspace = true }
 bytes = { workspace = true }
 cfg-if = { workspace = true }
 futures = { workspace = true }

--- a/crates/reqwest/src/lib.rs
+++ b/crates/reqwest/src/lib.rs
@@ -33,7 +33,7 @@ use futures::FutureExt;
 use futures::future::BoxFuture;
 use http_body_util::BodyDataStream;
 pub use http_cache_stream::X_CACHE;
-pub use http_cache_stream::X_CACHE_DIGEST;
+pub use http_cache_stream::X_CACHE_KEY;
 pub use http_cache_stream::X_CACHE_LOOKUP;
 use http_cache_stream::http::Extensions;
 use http_cache_stream::http::Uri;
@@ -183,11 +183,14 @@ impl<S: CacheStorage> reqwest_middleware::Middleware for Cache<S> {
 
 #[cfg(test)]
 mod test {
+    use std::fs::read_to_string;
     use std::sync::Arc;
     use std::sync::Mutex;
 
+    use http_cache_stream::cache_key;
     use http_cache_stream::http;
     use http_cache_stream::storage::DefaultCacheStorage;
+    use reqwest::Method;
     use reqwest::Response;
     use reqwest::StatusCode;
     use reqwest::header;
@@ -248,9 +251,11 @@ mod test {
 
     #[tokio::test]
     async fn no_store() {
+        const URI: &str = "http://test.local";
         const BODY: &str = "hello world!";
-        // Blake3 digest of the body (from https://emn178.github.io/online-tools/blake3/)
-        const DIGEST: &str = "3aa61c409fd7717c9d9c639202af2fae470c0ef669be7ba2caea5779cb534e9d";
+
+        // Determine the expected cache key
+        let key = cache_key(&Method::GET, &URI.parse().unwrap(), &Default::default());
 
         let dir = tempdir().unwrap();
         let cache = Arc::new(Cache::new(DefaultCacheStorage::new(dir.path())));
@@ -270,18 +275,18 @@ mod test {
         );
 
         // Response should not be served from the cache or stored
-        let response = client.get("http://test.local/").send().await.unwrap();
+        let response = client.get(URI).send().await.unwrap();
         assert_eq!(
             response.headers().get(header::CACHE_CONTROL).unwrap(),
             "no-store"
         );
         assert_eq!(response.headers().get(X_CACHE_LOOKUP).unwrap(), "MISS");
         assert_eq!(response.headers().get(X_CACHE).unwrap(), "MISS");
-        assert!(response.headers().get(X_CACHE_DIGEST).is_none());
+        assert!(response.headers().get(X_CACHE_KEY).is_none());
         assert_eq!(response.text().await.unwrap(), BODY);
 
         // Ensure the body wasn't stored in the cache
-        assert!(!cache.storage().body_path(DIGEST).is_file());
+        assert!(!cache.storage().body_path(&key).is_file());
 
         // Response should *still* not be served from the cache or stored
         let response = client.get("http://test.local/").send().await.unwrap();
@@ -291,18 +296,20 @@ mod test {
         );
         assert_eq!(response.headers().get(X_CACHE_LOOKUP).unwrap(), "MISS");
         assert_eq!(response.headers().get(X_CACHE).unwrap(), "MISS");
-        assert!(response.headers().get(X_CACHE_DIGEST).is_none());
+        assert!(response.headers().get(X_CACHE_KEY).is_none());
         assert_eq!(response.text().await.unwrap(), BODY);
 
         // Ensure the body wasn't stored in the cache
-        assert!(!cache.storage().body_path(DIGEST).is_file());
+        assert!(!cache.storage().body_path(&key).is_file());
     }
 
     #[tokio::test]
     async fn max_age() {
+        const URI: &str = "http://test.local";
         const BODY: &str = "hello world!";
-        // Blake3 digest of the body (from https://emn178.github.io/online-tools/blake3/)
-        const DIGEST: &str = "3aa61c409fd7717c9d9c639202af2fae470c0ef669be7ba2caea5779cb534e9d";
+
+        // Determine the expected cache key
+        let key = cache_key(&Method::GET, &URI.parse().unwrap(), &Default::default());
 
         let dir = tempdir().unwrap();
         let cache = Arc::new(
@@ -319,18 +326,21 @@ mod test {
         );
 
         // First response should not be served from the cache
-        let response = client.get("http://test.local/").send().await.unwrap();
+        let response = client.get(URI).send().await.unwrap();
         assert_eq!(
             response.headers().get(header::CACHE_CONTROL).unwrap(),
             "max-age=1000"
         );
         assert_eq!(response.headers().get(X_CACHE_LOOKUP).unwrap(), "MISS");
         assert_eq!(response.headers().get(X_CACHE).unwrap(), "MISS");
-        assert!(response.headers().get(X_CACHE_DIGEST).is_none());
+        assert!(response.headers().get(X_CACHE_KEY).is_none());
         assert_eq!(response.text().await.unwrap(), BODY);
 
         // Ensure the body was stored in the cache
-        assert!(cache.storage().body_path(DIGEST).is_file());
+        assert_eq!(
+            read_to_string(cache.storage().body_path(&key)).unwrap(),
+            BODY
+        );
 
         // Second response should be served from the cache without revalidation
         // If a revalidation is made, the mock middleware will panic since there was
@@ -345,24 +355,30 @@ mod test {
         assert_eq!(
             response
                 .headers()
-                .get(X_CACHE_DIGEST)
+                .get(X_CACHE_KEY)
                 .map(|v| v.to_str().unwrap())
                 .unwrap(),
-            DIGEST
+            key,
         );
         assert_eq!(response.text().await.unwrap(), BODY);
+        assert_eq!(
+            read_to_string(cache.storage().body_path(&key)).unwrap(),
+            BODY
+        );
     }
 
     #[tokio::test]
     async fn cache_hit_unmodified() {
+        const URI: &str = "http://test.local";
         const BODY: &str = "hello world!";
-        // Blake3 digest of the body (from https://emn178.github.io/online-tools/blake3/)
-        const DIGEST: &str = "3aa61c409fd7717c9d9c639202af2fae470c0ef669be7ba2caea5779cb534e9d";
 
         #[derive(Default)]
         struct State {
             revalidated: bool,
         }
+
+        // Determine the expected cache key
+        let key = cache_key(&Method::GET, &URI.parse().unwrap(), &Default::default());
 
         let dir = tempdir().unwrap();
         let state = Arc::new(Mutex::new(State::default()));
@@ -389,11 +405,14 @@ mod test {
         let response = client.get("http://test.local/").send().await.unwrap();
         assert_eq!(response.headers().get(X_CACHE_LOOKUP).unwrap(), "MISS");
         assert_eq!(response.headers().get(X_CACHE).unwrap(), "MISS");
-        assert!(response.headers().get(X_CACHE_DIGEST).is_none());
+        assert!(response.headers().get(X_CACHE_KEY).is_none());
         assert_eq!(response.text().await.unwrap(), BODY);
 
         // Ensure the body was stored in the cache
-        assert!(cache.storage().body_path(DIGEST).is_file());
+        assert_eq!(
+            read_to_string(cache.storage().body_path(&key)).unwrap(),
+            BODY
+        );
 
         // Assert no revalidation took place
         assert!(!state.lock().unwrap().revalidated);
@@ -405,12 +424,16 @@ mod test {
         assert_eq!(
             response
                 .headers()
-                .get(X_CACHE_DIGEST)
+                .get(X_CACHE_KEY)
                 .map(|v| v.to_str().unwrap())
                 .unwrap(),
-            DIGEST
+            &key
         );
         assert_eq!(response.text().await.unwrap(), BODY);
+        assert_eq!(
+            read_to_string(cache.storage().body_path(&key)).unwrap(),
+            BODY
+        );
 
         // Assert a revalidation took place
         assert!(state.lock().unwrap().revalidated);
@@ -418,18 +441,17 @@ mod test {
 
     #[tokio::test]
     async fn cache_hit_modified() {
+        const URI: &str = "http://test.local";
         const BODY: &str = "hello world!";
         const MODIFIED_BODY: &str = "hello world!!!";
-        // Blake3 digest of the body (from https://emn178.github.io/online-tools/blake3/)
-        const DIGEST: &str = "3aa61c409fd7717c9d9c639202af2fae470c0ef669be7ba2caea5779cb534e9d";
-        // Blake3 digest of the modified body (from https://emn178.github.io/online-tools/blake3/)
-        const MODIFIED_DIGEST: &str =
-            "22b8d362b2e8064356915b1451f630d1d920b427d3b2f9b3432fbf4c03d94184";
 
         #[derive(Default)]
         struct State {
             revalidated: bool,
         }
+
+        // Determine the expected cache key
+        let key = cache_key(&Method::GET, &URI.parse().unwrap(), &Default::default());
 
         let dir = tempdir().unwrap();
         let state = Arc::new(Mutex::new(State::default()));
@@ -457,11 +479,14 @@ mod test {
         let response = client.get("http://test.local/").send().await.unwrap();
         assert_eq!(response.headers().get(X_CACHE_LOOKUP).unwrap(), "MISS");
         assert_eq!(response.headers().get(X_CACHE).unwrap(), "MISS");
-        assert!(response.headers().get(X_CACHE_DIGEST).is_none());
+        assert!(response.headers().get(X_CACHE_KEY).is_none());
         assert_eq!(response.text().await.unwrap(), BODY);
 
         // Ensure the body was stored in the cache
-        assert!(cache.storage().body_path(DIGEST).is_file());
+        assert_eq!(
+            read_to_string(cache.storage().body_path(&key)).unwrap(),
+            BODY
+        );
 
         // Assert no revalidation took place
         assert!(!state.lock().unwrap().revalidated);
@@ -470,11 +495,14 @@ mod test {
         let response = client.get("http://test.local/").send().await.unwrap();
         assert_eq!(response.headers().get(X_CACHE_LOOKUP).unwrap(), "HIT");
         assert_eq!(response.headers().get(X_CACHE).unwrap(), "MISS");
-        assert!(response.headers().get(X_CACHE_DIGEST).is_none());
+        assert!(response.headers().get(X_CACHE_KEY).is_none());
         assert_eq!(response.text().await.unwrap(), MODIFIED_BODY);
 
         // Ensure the body was stored in the cache
-        assert!(cache.storage().body_path(MODIFIED_DIGEST).is_file());
+        assert_eq!(
+            read_to_string(cache.storage().body_path(&key)).unwrap(),
+            MODIFIED_BODY
+        );
 
         // Assert a revalidation took place and reset the flag back to false
         assert!(std::mem::take(&mut state.lock().unwrap().revalidated));
@@ -486,12 +514,16 @@ mod test {
         assert_eq!(
             response
                 .headers()
-                .get(X_CACHE_DIGEST)
+                .get(X_CACHE_KEY)
                 .map(|v| v.to_str().unwrap())
                 .unwrap(),
-            MODIFIED_DIGEST
+            &key
         );
         assert_eq!(response.text().await.unwrap(), MODIFIED_BODY);
+        assert_eq!(
+            read_to_string(cache.storage().body_path(&key)).unwrap(),
+            MODIFIED_BODY
+        );
 
         // Assert a revalidation took place
         assert!(state.lock().unwrap().revalidated);

--- a/crates/reqwest/src/lib.rs
+++ b/crates/reqwest/src/lib.rs
@@ -289,7 +289,7 @@ mod test {
         assert!(!cache.storage().body_path(&key).is_file());
 
         // Response should *still* not be served from the cache or stored
-        let response = client.get("http://test.local/").send().await.unwrap();
+        let response = client.get(URI).send().await.unwrap();
         assert_eq!(
             response.headers().get(header::CACHE_CONTROL).unwrap(),
             "no-store"
@@ -345,7 +345,7 @@ mod test {
         // Second response should be served from the cache without revalidation
         // If a revalidation is made, the mock middleware will panic since there was
         // only one response defined
-        let response = client.get("http://test.local/").send().await.unwrap();
+        let response = client.get(URI).send().await.unwrap();
         assert_eq!(
             response.headers().get(header::CACHE_CONTROL).unwrap(),
             "max-age=1000"
@@ -402,7 +402,7 @@ mod test {
         );
 
         // First response should be a miss
-        let response = client.get("http://test.local/").send().await.unwrap();
+        let response = client.get(URI).send().await.unwrap();
         assert_eq!(response.headers().get(X_CACHE_LOOKUP).unwrap(), "MISS");
         assert_eq!(response.headers().get(X_CACHE).unwrap(), "MISS");
         assert!(response.headers().get(X_CACHE_KEY).is_none());
@@ -418,7 +418,7 @@ mod test {
         assert!(!state.lock().unwrap().revalidated);
 
         // Second response should be served from the cache
-        let response = client.get("http://test.local/").send().await.unwrap();
+        let response = client.get(URI).send().await.unwrap();
         assert_eq!(response.headers().get(X_CACHE_LOOKUP).unwrap(), "HIT");
         assert_eq!(response.headers().get(X_CACHE).unwrap(), "HIT");
         assert_eq!(
@@ -476,7 +476,7 @@ mod test {
         );
 
         // First response should be a miss
-        let response = client.get("http://test.local/").send().await.unwrap();
+        let response = client.get(URI).send().await.unwrap();
         assert_eq!(response.headers().get(X_CACHE_LOOKUP).unwrap(), "MISS");
         assert_eq!(response.headers().get(X_CACHE).unwrap(), "MISS");
         assert!(response.headers().get(X_CACHE_KEY).is_none());
@@ -492,7 +492,8 @@ mod test {
         assert!(!state.lock().unwrap().revalidated);
 
         // Second response should not be served from the cache (was modified)
-        let response = client.get("http://test.local/").send().await.unwrap();
+        let response = client.get(URI).send().await.unwrap();
+
         assert_eq!(response.headers().get(X_CACHE_LOOKUP).unwrap(), "HIT");
         assert_eq!(response.headers().get(X_CACHE).unwrap(), "MISS");
         assert!(response.headers().get(X_CACHE_KEY).is_none());
@@ -508,7 +509,8 @@ mod test {
         assert!(std::mem::take(&mut state.lock().unwrap().revalidated));
 
         // Second response should be served from the cache (not modified)
-        let response = client.get("http://test.local/").send().await.unwrap();
+        let response = client.get(URI).send().await.unwrap();
+
         assert_eq!(response.headers().get(X_CACHE_LOOKUP).unwrap(), "HIT");
         assert_eq!(response.headers().get(X_CACHE).unwrap(), "HIT");
         assert_eq!(
@@ -527,5 +529,55 @@ mod test {
 
         // Assert a revalidation took place
         assert!(state.lock().unwrap().revalidated);
+    }
+
+    #[tokio::test]
+    async fn unsafe_requests() {
+        const URI: &str = "http://test.local";
+        const BODY: &str = "hello world!";
+        const CREATED_BODY: &str = "created!";
+
+        let dir = tempdir().unwrap();
+        let cache = Arc::new(Cache::new(DefaultCacheStorage::new(dir.path())));
+        // Test for both GET and HEAD invalidation after an "unsafe" request
+        for method in &[Method::GET, Method::HEAD] {
+            let mock = Arc::new(MockMiddleware::new([
+                http::Response::builder().body(BODY).unwrap(),
+                http::Response::builder()
+                    .status(StatusCode::CREATED)
+                    .body(CREATED_BODY)
+                    .unwrap(),
+            ]));
+            let client = ClientWithMiddleware::new(
+                Default::default(),
+                vec![cache.clone() as Arc<dyn Middleware>, mock.clone()],
+            );
+
+            // Determine the expected cache key
+            let key = cache_key(method, &URI.parse().unwrap(), &Default::default());
+
+            // First response should be a miss, but the body should be stored
+            let response = client.request(method.clone(), URI).send().await.unwrap();
+            assert_eq!(response.headers().get(X_CACHE_LOOKUP).unwrap(), "MISS");
+            assert_eq!(response.headers().get(X_CACHE).unwrap(), "MISS");
+            assert!(response.headers().get(X_CACHE_KEY).is_none());
+            assert_eq!(response.text().await.unwrap(), BODY);
+
+            // Ensure the body was stored in the cache
+            assert_eq!(
+                read_to_string(cache.storage().body_path(&key)).unwrap(),
+                BODY
+            );
+
+            // Make an "unsafe" request to the cached URL
+            let response = client.post(URI).send().await.unwrap();
+            assert_eq!(response.headers().get(X_CACHE_LOOKUP).unwrap(), "MISS");
+            assert_eq!(response.headers().get(X_CACHE).unwrap(), "MISS");
+            assert!(response.headers().get(X_CACHE_KEY).is_none());
+            assert_eq!(response.text().await.unwrap(), CREATED_BODY);
+
+            // Ensure the cached body is now empty (truncated)
+            assert_eq!(read_to_string(cache.storage().body_path(&key)).unwrap(), "");
+        }
     }
 }

--- a/src/body.rs
+++ b/src/body.rs
@@ -9,7 +9,6 @@ use std::task::ready;
 
 use anyhow::Context as _;
 use anyhow::Result;
-use blake3::Hasher;
 use bytes::Bytes;
 use bytes::BytesMut;
 use futures::Stream;
@@ -43,10 +42,8 @@ pin_project! {
             path: Option<TempPath>,
             // The current bytes read from the upstream body.
             current: Bytes,
-            // The hasher used to hash the body.
-            hasher: Hasher,
             // The callback to invoke once the cache file is completed.
-            callback: Option<Box<dyn FnOnce(String, TempPath) -> BoxFuture<'static, Result<()>> + Send>>,
+            callback: Option<Box<dyn FnOnce(TempPath) -> BoxFuture<'static, Result<()>> + Send>>,
         },
         /// The cache file is being flushed.
         FlushingFile {
@@ -55,10 +52,8 @@ pin_project! {
             writer: Option<runtime::BufWriter<runtime::File>>,
             // The temporary path of the cache file.
             path: Option<TempPath>,
-            // The digest of the response body.
-            digest: String,
             // The callback to invoke once the cache file is completed.
-            callback: Option<Box<dyn FnOnce(String, TempPath) -> BoxFuture<'static, Result<()>> + Send>>,
+            callback: Option<Box<dyn FnOnce(TempPath) -> BoxFuture<'static, Result<()>> + Send>>,
         },
         /// The callback is being invoked.
         InvokingCallback {
@@ -85,7 +80,7 @@ impl<B> CachingUpstreamSource<B> {
     /// The callback is invoked after the body has been written to the cache.
     async fn new<F>(upstream: B, temp_dir: &Path, callback: F) -> Result<Self>
     where
-        F: FnOnce(String, TempPath) -> BoxFuture<'static, Result<()>> + Send + 'static,
+        F: FnOnce(TempPath) -> BoxFuture<'static, Result<()>> + Send + 'static,
     {
         let path = NamedTempFile::new_in(temp_dir)
             .context("failed to create temporary body file for cache storage")?
@@ -105,7 +100,6 @@ impl<B> CachingUpstreamSource<B> {
                 path: Some(path),
                 callback: Some(Box::new(callback)),
                 current: Bytes::new(),
-                hasher: Hasher::new(),
             },
         })
     }
@@ -132,7 +126,6 @@ where
                     mut writer,
                     path,
                     current,
-                    hasher,
                     callback,
                 } => {
                     // Check to see if a read is needed
@@ -142,8 +135,6 @@ where
                                 let frame = frame.map_data(Into::into);
                                 match frame.into_data() {
                                     Ok(data) if !data.is_empty() => {
-                                        // Update the hasher with the data that was read
-                                        hasher.update(&data);
                                         *current = data;
                                     }
                                     Ok(_) => continue,
@@ -160,7 +151,6 @@ where
                             None => {
                                 let writer = writer.take();
                                 let path = path.take();
-                                let digest = hex::encode(hasher.finalize().as_bytes());
                                 let callback = callback.take();
 
                                 // We're done reading from upstream, transition to the flushing
@@ -169,7 +159,6 @@ where
                                     state: CachingUpstreamSourceState::FlushingFile {
                                         writer,
                                         path,
-                                        digest,
                                         callback,
                                     },
                                 });
@@ -196,7 +185,6 @@ where
                 ProjectedCachingUpstreamSourceState::FlushingFile {
                     mut writer,
                     path,
-                    digest,
                     callback,
                 } => {
                     // Attempt to poll the writer for flush
@@ -204,11 +192,10 @@ where
                         Ok(_) => {
                             drop(writer.take());
                             let path = path.take().unwrap();
-                            let digest = std::mem::take(digest);
                             let callback = callback.take().unwrap();
 
                             // Invoke the callback and transition to the invoking callback state
-                            let future = callback(digest, path);
+                            let future = callback(path);
                             self.set(Self {
                                 state: CachingUpstreamSourceState::InvokingCallback { future },
                             });
@@ -401,7 +388,7 @@ where
         callback: F,
     ) -> Result<Self>
     where
-        F: FnOnce(String, TempPath) -> BoxFuture<'static, Result<()>> + Send + 'static,
+        F: FnOnce(TempPath) -> BoxFuture<'static, Result<()>> + Send + 'static,
     {
         Ok(Self {
             source: BodySource::CachingUpstream {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -37,20 +37,17 @@ pub const X_CACHE_LOOKUP: &str = "x-cache-lookup";
 /// Value will be `HIT` if a response was served from the cache, `MISS` if not.
 pub const X_CACHE: &str = "x-cache";
 
-/// The name of the `x-cache-digest` custom header.
+/// The name of the `x-cache-key` custom header.
 ///
-/// This header is only present in the response when returning a body from the
+/// This header is only present in the response when serving a body from the
 /// cache.
 ///
 /// This can be used to read a body directly from cache storage rather than
 /// reading the body through the response.
-///
-/// This header is only present when a cached response body is being served from
-/// the cache.
-pub const X_CACHE_DIGEST: &str = "x-cache-digest";
+pub const X_CACHE_KEY: &str = "x-cache-key";
 
-/// Gets the storage key for a request.
-fn storage_key(method: &Method, uri: &Uri, headers: &HeaderMap) -> String {
+/// Gets the cache key for a request.
+pub fn cache_key(method: &Method, uri: &Uri, headers: &HeaderMap) -> String {
     let mut hasher = Sha256::new();
     hasher.update(method.as_str());
     hasher.update(":");
@@ -137,7 +134,7 @@ trait ResponseExt {
         &mut self,
         lookup: CacheLookupStatus,
         status: CacheStatus,
-        digest: Option<&str>,
+        key: Option<&str>,
     );
 }
 
@@ -184,7 +181,7 @@ impl<B> ResponseExt for Response<B> {
         &mut self,
         lookup: CacheLookupStatus,
         status: CacheStatus,
-        digest: Option<&str>,
+        key: Option<&str>,
     ) {
         let headers = self.headers_mut();
         headers.insert(
@@ -195,8 +192,8 @@ impl<B> ResponseExt for Response<B> {
             X_CACHE,
             status.to_string().parse().expect("value should parse"),
         );
-        if let Some(digest) = digest {
-            headers.insert(X_CACHE_DIGEST, digest.parse().expect("value should parse"));
+        if let Some(key) = key {
+            headers.insert(X_CACHE_KEY, key.parse().expect("value should parse"));
         }
     }
 }
@@ -364,7 +361,7 @@ where
         let method = request.method();
         let uri = request.uri();
 
-        let key = storage_key(method, uri, request.headers());
+        let key = cache_key(method, uri, request.headers());
         if matches!(*method, Method::GET | Method::HEAD) {
             match self.storage.get(&key).await {
                 Ok(Some(stored)) => {
@@ -461,7 +458,7 @@ where
             // If the request is not safe, assume the resource has been modified and delete
             // any cached responses we may have for HEAD/GET
             for method in [Method::HEAD, Method::GET] {
-                let key = storage_key(&method, &request_like.uri, &request_like.headers);
+                let key = cache_key(&method, &request_like.uri, &request_like.headers);
                 if let Err(e) = self.storage.delete(&key).await {
                     debug!(
                         method = method.as_str(),
@@ -504,7 +501,6 @@ where
                     authority = request_like.uri.authority().map(Authority::as_str),
                     path = request_like.uri.path(),
                     key,
-                    digest = stored.digest,
                     "response is still fresh: responding with body from storage"
                 );
 
@@ -512,7 +508,7 @@ where
                 stored.response.set_cache_status(
                     CacheLookupStatus::Hit,
                     CacheStatus::Hit,
-                    Some(&stored.digest),
+                    Some(&key),
                 );
                 return Ok(stored.response);
             }
@@ -616,22 +612,14 @@ where
                              replying with not modified"
                         );
 
-                        Self::prepare_stale_response(
-                            &request_like.uri,
-                            &mut stored.response,
-                            &stored.digest,
-                        );
+                        Self::prepare_stale_response(&request_like.uri, &mut stored.response, &key);
                         Ok(stored.response)
                     }
                     AfterResponse::NotModified(policy, parts) => {
                         stored.response.extend_headers(parts.headers);
 
                         let (parts, body) = stored.response.into_parts();
-                        match self
-                            .storage
-                            .put(&key, &parts, &policy, &stored.digest)
-                            .await
-                        {
+                        match self.storage.put(&key, &parts, &policy).await {
                             Ok(_) => {
                                 debug!(
                                     method = request_like.method.as_str(),
@@ -639,7 +627,6 @@ where
                                     authority = request_like.uri.authority().map(Authority::as_str),
                                     path = request_like.uri.path(),
                                     key,
-                                    digest = stored.digest,
                                     "response updated in cache successfully"
                                 );
 
@@ -648,7 +635,7 @@ where
                                 cached_response.set_cache_status(
                                     CacheLookupStatus::Hit,
                                     CacheStatus::Hit,
-                                    Some(&stored.digest),
+                                    Some(&key),
                                 );
                                 Ok(cached_response)
                             }
@@ -677,16 +664,11 @@ where
                     authority = request_like.uri.authority().map(Authority::as_str),
                     path = request_like.uri.path(),
                     key,
-                    stored.digest,
                     "failed to revalidate response: serving potentially stale body from storage \
                      with a warning"
                 );
 
-                Self::prepare_stale_response(
-                    &request_like.uri,
-                    &mut stored.response,
-                    &stored.digest,
-                );
+                Self::prepare_stale_response(&request_like.uri, &mut stored.response, &key);
                 Ok(stored.response)
             }
             Ok(mut response) => {
@@ -713,16 +695,11 @@ where
                         authority = request_like.uri.authority().map(Authority::as_str),
                         path = request_like.uri.path(),
                         key,
-                        stored.digest,
                         "failed to revalidate response: serving potentially stale body from \
                          storage with a warning"
                     );
 
-                    Self::prepare_stale_response(
-                        &request_like.uri,
-                        &mut stored.response,
-                        &stored.digest,
-                    );
+                    Self::prepare_stale_response(&request_like.uri, &mut stored.response, &key);
                     Ok(stored.response)
                 }
             }
@@ -730,7 +707,7 @@ where
     }
 
     /// Prepares a stale response for sending back to the client.
-    fn prepare_stale_response<B>(uri: &Uri, response: &mut Response<CacheBody<B>>, digest: &str) {
+    fn prepare_stale_response<B>(uri: &Uri, response: &mut Response<CacheBody<B>>, key: &str) {
         // If the server failed to give us a response, add the required warning to the
         // cached response:
         //   111 Revalidation failed
@@ -739,6 +716,6 @@ where
         //   due to an inability to reach the server.
         // (https://tools.ietf.org/html/rfc2616#section-14.46)
         response.add_warning(uri, 111, "Revalidation failed");
-        response.set_cache_status(CacheLookupStatus::Hit, CacheStatus::Hit, Some(digest));
+        response.set_cache_status(CacheLookupStatus::Hit, CacheStatus::Hit, Some(key));
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -49,26 +49,45 @@ pub const X_CACHE_KEY: &str = "x-cache-key";
 /// Gets the cache key for a request.
 pub fn cache_key(method: &Method, uri: &Uri, headers: &HeaderMap) -> String {
     let mut hasher = Sha256::new();
+
+    // Hash the method
+    hasher.update(method.as_str().len().to_le_bytes());
     hasher.update(method.as_str());
-    hasher.update(":");
 
+    // Hash the scheme if present
     if let Some(scheme) = uri.scheme_str() {
+        hasher.update(scheme.len().to_le_bytes());
         hasher.update(scheme);
+    } else {
+        hasher.update(0usize.to_le_bytes());
     }
 
-    hasher.update("://");
+    // Hash the authority if present
     if let Some(authority) = uri.authority() {
+        hasher.update(authority.as_str().len().to_le_bytes());
         hasher.update(authority.as_str());
+    } else {
+        hasher.update(0usize.to_le_bytes());
     }
 
+    // Hash the path
+    hasher.update(uri.path().len().to_le_bytes());
     hasher.update(uri.path());
 
+    // Hash the query string if present (note: not normalized)
     if let Some(query) = uri.query() {
+        hasher.update(query.len().to_le_bytes());
         hasher.update(query);
+    } else {
+        hasher.update(0usize.to_le_bytes());
     }
 
+    // Hash the range header if present
     if let Some(value) = headers.get(header::RANGE) {
+        hasher.update(value.as_bytes().len().to_le_bytes());
         hasher.update(value.as_bytes());
+    } else {
+        hasher.update(0usize.to_le_bytes());
     }
 
     let bytes = hasher.finalize();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -13,7 +13,6 @@ cfg_if::cfg_if! {
         pub use tokio::io::BufWriter;
         pub use tokio::io::AsyncWrite;
         pub use tokio::task::spawn_blocking;
-        pub use tokio::fs::remove_file;
 
         /// Helper for difference in `spawn_blocking` signatures.
         pub fn unwrap_task_output<T>(result: Result<T, tokio::task::JoinError>) -> Option<T> {
@@ -21,7 +20,6 @@ cfg_if::cfg_if! {
         }
     } else if #[cfg(feature = "smol")] {
         pub use smol::fs::File;
-        pub use smol::fs::remove_file;
         pub use smol::io::BufReader;
         pub use smol::io::BufWriter;
         pub use smol::io::AsyncWrite;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -13,6 +13,7 @@ cfg_if::cfg_if! {
         pub use tokio::io::BufWriter;
         pub use tokio::io::AsyncWrite;
         pub use tokio::task::spawn_blocking;
+        pub use tokio::fs::remove_file;
 
         /// Helper for difference in `spawn_blocking` signatures.
         pub fn unwrap_task_output<T>(result: Result<T, tokio::task::JoinError>) -> Option<T> {
@@ -23,6 +24,7 @@ cfg_if::cfg_if! {
         pub use smol::io::BufReader;
         pub use smol::io::BufWriter;
         pub use smol::io::AsyncWrite;
+        pub use smol::fs::remove_file;
         pub use smol::unblock as spawn_blocking;
 
         /// Helper for difference in `spawn_blocking` signatures.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -21,10 +21,10 @@ cfg_if::cfg_if! {
         }
     } else if #[cfg(feature = "smol")] {
         pub use smol::fs::File;
+        pub use smol::fs::remove_file;
         pub use smol::io::BufReader;
         pub use smol::io::BufWriter;
         pub use smol::io::AsyncWrite;
-        pub use smol::fs::remove_file;
         pub use smol::unblock as spawn_blocking;
 
         /// Helper for difference in `spawn_blocking` signatures.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -20,8 +20,6 @@ pub struct StoredResponse<B: Body> {
     pub response: Response<CacheBody<B>>,
     /// The current cache policy.
     pub policy: CachePolicy,
-    /// The response content digest.
-    pub digest: String,
 }
 
 /// A trait implemented on cache storage.
@@ -37,17 +35,13 @@ pub trait CacheStorage: Send + Sync + 'static {
         key: &str,
     ) -> impl Future<Output = Result<Option<StoredResponse<B>>>> + Send;
 
-    /// Puts a response with an existing content digest into the storage for the
-    /// given response key.
-    ///
-    /// The provided content digest must come from a previous call to
-    /// [`CacheStorage::get`].
+    /// Puts a response with an existing cached response body into the storage
+    /// for the given response key.
     fn put(
         &self,
         key: &str,
         parts: &Parts,
         policy: &CachePolicy,
-        digest: &str,
     ) -> impl Future<Output = Result<()>> + Send;
 
     /// Stores a new response body in the cache.
@@ -66,8 +60,8 @@ pub trait CacheStorage: Send + Sync + 'static {
     /// Deleting an unknown key is not considered an error.
     fn delete(&self, key: &str) -> impl Future<Output = Result<()>> + Send;
 
-    /// Gets the path to a response body for the given content digest.
+    /// Gets the path to a response body for the given cache key.
     ///
     /// This method does not verify the content's existence.
-    fn body_path(&self, digest: &str) -> PathBuf;
+    fn body_path(&self, key: &str) -> PathBuf;
 }

--- a/src/storage/default.rs
+++ b/src/storage/default.rs
@@ -17,10 +17,10 @@ use http::Version;
 use http::response::Parts;
 use http_body::Body;
 use http_cache_semantics::CachePolicy;
+use runtime::remove_file;
 use serde::Deserialize;
 use serde::Serialize;
 use tempfile::TempPath;
-use tokio::fs::remove_file;
 use tracing::debug;
 
 use super::StoredResponse;

--- a/src/storage/default.rs
+++ b/src/storage/default.rs
@@ -19,6 +19,8 @@ use http_body::Body;
 use http_cache_semantics::CachePolicy;
 use serde::Deserialize;
 use serde::Serialize;
+use tempfile::TempPath;
+use tokio::fs::remove_file;
 use tracing::debug;
 
 use super::StoredResponse;
@@ -54,9 +56,6 @@ struct CachedResponseRef<'a> {
     #[serde(with = "http_serde::header_map")]
     headers: &'a HeaderMap,
 
-    /// The content digest of the response.
-    digest: &'a str,
-
     /// The last used cached policy.
     policy: &'a CachePolicy,
 }
@@ -78,9 +77,6 @@ struct CachedResponse {
     #[serde(with = "http_serde::header_map")]
     headers: HeaderMap,
 
-    /// The content digest of the response.
-    digest: String,
-
     /// The last used cached policy.
     policy: CachePolicy,
 }
@@ -99,23 +95,22 @@ struct CachedResponse {
 /// │  │  ├─ <key>
 /// │  │  ├─ ...
 /// │  ├─ content/
-/// │  │  ├─ <digest>
-/// │  │  ├─ <digest>
+/// │  │  ├─ <key>
+/// │  │  ├─ <key>
 /// │  │  ├─ ...
 /// │  ├─ tmp/
 /// ```
 ///
 /// Where `<root>` is the root storage directory, `<storage-version>` is a
-/// constant that changes when the directory layout changes (currently `v1`),
-/// `<key>` is supplied by the cache, and `<digest>` is the calculated digest of
-/// a response body.
+/// constant that changes when the directory layout changes (currently `v1`) and
+/// `<key>` is supplied by the cache.
 ///
 /// ## The `responses` directory
 ///
 /// The `responses` directory contains a file for each cached response.
 ///
 /// The file is a bincode-serialized `CachedResponse` that contains information
-/// about the response, including the response body content digest.
+/// about the response.
 ///
 /// ### Response file locking
 ///
@@ -129,18 +124,12 @@ struct CachedResponse {
 ///
 /// The `content` directory contains a file for each cached response body.
 ///
-/// The file name is the digest of the response body contents.
-///
-/// Currently the [`blake3`][blake3] hash algorithm is used for calculating
-/// response body digests.
+/// The file name is the key supplied by the cache.
 ///
 /// ## The `tmp` directory
 ///
 /// The `tmp` directory is used for temporarily storing response bodies as they
 /// are saved to the cache.
-///
-/// The content digest of the response is calculated as the response is written
-/// into temporary storage.
 ///
 /// Once the response body has been fully read, the temporary file is atomically
 /// renamed to its content directory location; if the content already exists,
@@ -159,8 +148,6 @@ struct CachedResponse {
 /// If an error occurs while updating a cache entry with
 /// [`DefaultCacheStorage::put`], a future [`DefaultCacheStorage::get`] call
 /// will treat the entry as not present.
-///
-/// [blake3]: https://github.com/BLAKE3-team/BLAKE3
 #[derive(Clone)]
 pub struct DefaultCacheStorage(Arc<DefaultCacheStorageInner>);
 
@@ -179,7 +166,7 @@ impl CacheStorage for DefaultCacheStorage {
         };
 
         // Open the response body
-        let path = self.body_path(&cached.digest);
+        let path = self.body_path(key);
         let body = match runtime::File::open(&path)
             .await
             .map(Some)
@@ -217,17 +204,10 @@ impl CacheStorage for DefaultCacheStorage {
                 })?)
                 .expect("should be valid"),
             policy: cached.policy,
-            digest: cached.digest,
         }))
     }
 
-    async fn put(
-        &self,
-        key: &str,
-        parts: &Parts,
-        policy: &CachePolicy,
-        digest: &str,
-    ) -> Result<()> {
+    async fn put(&self, key: &str, parts: &Parts, policy: &CachePolicy) -> Result<()> {
         self.0
             .write_response(
                 key,
@@ -235,9 +215,9 @@ impl CacheStorage for DefaultCacheStorage {
                     status: parts.status,
                     version: parts.version,
                     headers: &parts.headers,
-                    digest,
                     policy,
                 },
+                None,
             )
             .await
     }
@@ -260,25 +240,13 @@ impl CacheStorage for DefaultCacheStorage {
         })?;
 
         // Create a new caching body from the upstream body
-        // The provided callback will be invoked once the cache file hsa been completed
+        // The provided callback will be invoked once the stream has completed
         let status = parts.status;
         let version = parts.version;
         let headers = parts.headers.clone();
 
-        let body = CacheBody::from_caching_upstream(body, &temp_dir, move |digest, path| {
+        let body = CacheBody::from_caching_upstream(body, &temp_dir, move |content| {
             async move {
-                let content_path = inner.content_path(&digest);
-                fs::create_dir_all(content_path.parent().expect("should have parent"))
-                    .context("failed to create content directory")?;
-
-                // Atomically persist the temp file into the `content` location
-                path.persist(&content_path).with_context(|| {
-                    format!(
-                        "failed to persist downloaded body to content path `{path}`",
-                        path = content_path.display()
-                    )
-                })?;
-
                 // Update the response
                 inner
                     .write_response(
@@ -287,14 +255,13 @@ impl CacheStorage for DefaultCacheStorage {
                             status,
                             version,
                             headers: &headers,
-                            digest: &digest,
                             policy: &policy,
                         },
+                        Some(content),
                     )
                     .await?;
 
-                debug!(key, digest, "response body stored successfully");
-
+                debug!(key, "response body stored successfully");
                 Ok(())
             }
             .boxed()
@@ -308,12 +275,16 @@ impl CacheStorage for DefaultCacheStorage {
         // Acquire an exclusive lock on the response file
         // By acquiring the lock, we truncate the file; any attempt to deserialize an
         // empty response file will fail and be treated as not-present
-        self.0.lock_response_exclusive(key).await?;
+        let _lock = self.0.lock_response_exclusive(key).await?;
+
+        // Delete the associated content file
+        let _ = remove_file(self.0.content_path(key)).await;
+
         Ok(())
     }
 
-    fn body_path(&self, digest: &str) -> PathBuf {
-        self.0.content_path(digest)
+    fn body_path(&self, key: &str) -> PathBuf {
+        self.0.content_path(key)
     }
 }
 
@@ -331,11 +302,11 @@ impl DefaultCacheStorageInner {
     }
 
     /// Calculates the path to a content file.
-    fn content_path(&self, digest: &str) -> PathBuf {
+    fn content_path(&self, key: &str) -> PathBuf {
         let mut path = self.0.to_path_buf();
         path.push(STORAGE_VERSION);
         path.push(CONTENT_DIRECTORY_NAME);
-        path.push(digest);
+        path.push(key);
         path
     }
 
@@ -372,14 +343,35 @@ impl DefaultCacheStorageInner {
     /// Writes a response to storage for the given key.
     ///
     /// This method will block if the response file is locked.
-    async fn write_response(&self, key: &str, response: CachedResponseRef<'_>) -> Result<()> {
+    async fn write_response(
+        &self,
+        key: &str,
+        response: CachedResponseRef<'_>,
+        content: Option<TempPath>,
+    ) -> Result<()> {
         // Acquire a shared lock on the response file
         let mut file = self.lock_response_exclusive(key).await?;
 
         // Encode the response
         bincode::serialize_into(&mut file, &response)
             .with_context(|| format!("failed to serialize response data for cache key `{key}`"))
-            .map(|_| ())
+            .map(|_| ())?;
+
+        if let Some(content) = content {
+            let content_path = self.content_path(key);
+            fs::create_dir_all(content_path.parent().expect("should have parent"))
+                .context("failed to create content directory")?;
+
+            // Atomically persist the temporary content file into the content location
+            content.persist(&content_path).with_context(|| {
+                format!(
+                    "failed to persist downloaded body to content path `{path}`",
+                    path = content_path.display()
+                )
+            })?;
+        }
+
+        Ok(())
     }
 
     /// Locks a response file for shared access.
@@ -502,7 +494,6 @@ mod test {
     async fn cache_hit() {
         const KEY: &str = "key";
         const BODY: &str = "hello world";
-        const DIGEST: &str = "d74981efa70a0c880b8d8c1985d075dbcbf679b99a5f9914e5aaf96b831a9e24";
         const HEADER_NAME: &str = "foo";
         const HEADER_VALUE: &str = "bar";
 
@@ -541,7 +532,6 @@ mod test {
             .unwrap()
             .unwrap();
         assert_eq!(data, BODY);
-        assert_eq!(cached.digest, DIGEST);
 
         // Create an "updated" response and put it into the cache with the same body
         let response = Response::builder()
@@ -551,7 +541,7 @@ mod test {
         let policy = CachePolicy::new(&request, &response);
 
         let (parts, _) = response.into_parts();
-        storage.put(KEY, &parts, &policy, DIGEST).await.unwrap();
+        storage.put(KEY, &parts, &policy).await.unwrap();
 
         // Lookup the cache entry (should exist with the header)
         let cached = storage.get::<String>(KEY).await.unwrap().unwrap();
@@ -571,7 +561,6 @@ mod test {
             .unwrap()
             .unwrap();
         assert_eq!(data, BODY);
-        assert_eq!(cached.digest, DIGEST);
 
         // Delete the key and ensure it no longer exists
         storage.delete(KEY).await.unwrap();

--- a/src/storage/default.rs
+++ b/src/storage/default.rs
@@ -3,6 +3,7 @@
 use std::fs;
 use std::fs::File;
 use std::io;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -17,7 +18,6 @@ use http::Version;
 use http::response::Parts;
 use http_body::Body;
 use http_cache_semantics::CachePolicy;
-use runtime::remove_file;
 use serde::Deserialize;
 use serde::Serialize;
 use tempfile::TempPath;
@@ -120,6 +120,11 @@ struct CachedResponse {
 /// This is used to coordinate access to the storage via this library; it does
 /// not protect against external modifications to the storage.
 ///
+/// There are two locks involved: one for the response file and one for the
+/// content file. The content file lock should only be acquired when the
+/// corresponding lock type (read or write) has first been acquired on the
+/// response file.
+///
 /// ## The `content` directory
 ///
 /// The `content` directory contains a file for each cached response body.
@@ -132,8 +137,8 @@ struct CachedResponse {
 /// are saved to the cache.
 ///
 /// Once the response body has been fully read, the temporary file is atomically
-/// renamed to its content directory location; if the content already exists,
-/// the temporary file is deleted.
+/// renamed to its content directory location and will replace any existing
+/// file.
 ///
 /// ## Integrity
 ///
@@ -160,50 +165,21 @@ impl DefaultCacheStorage {
 
 impl CacheStorage for DefaultCacheStorage {
     async fn get<B: Body + Send>(&self, key: &str) -> Result<Option<StoredResponse<B>>> {
-        let cached = match self.0.read_response(key).await? {
+        let (response, body) = match self.0.read_response(key).await? {
             Some(response) => response,
-            None => return Ok(None),
-        };
-
-        // Open the response body
-        let path = self.body_path(key);
-        let body = match runtime::File::open(&path)
-            .await
-            .map(Some)
-            .or_else(|e| {
-                if e.kind() == io::ErrorKind::NotFound {
-                    Ok(None)
-                } else {
-                    Err(e)
-                }
-            })
-            .with_context(|| {
-                format!(
-                    "failed to open response body `{path}`",
-                    path = path.display()
-                )
-            })? {
-            Some(file) => file,
             None => return Ok(None),
         };
 
         // Build a response from the cached parts
         let mut builder = Response::builder()
-            .version(cached.version)
-            .status(cached.status);
+            .version(response.version)
+            .status(response.status);
         let headers = builder.headers_mut().expect("should be valid");
-        headers.extend(cached.headers);
+        headers.extend(response.headers);
 
         Ok(Some(StoredResponse {
-            response: builder
-                .body(CacheBody::from_file(body).await.with_context(|| {
-                    format!(
-                        "failed to create response body for `{path}`",
-                        path = path.display()
-                    )
-                })?)
-                .expect("should be valid"),
-            policy: cached.policy,
+            response: builder.body(body).expect("should be valid"),
+            policy: response.policy,
         }))
     }
 
@@ -272,14 +248,12 @@ impl CacheStorage for DefaultCacheStorage {
     }
 
     async fn delete(&self, key: &str) -> Result<()> {
-        // Acquire an exclusive lock on the response file
-        // By acquiring the lock, we truncate the file; any attempt to deserialize an
-        // empty response file will fail and be treated as not-present
-        let _lock = self.0.lock_response_exclusive(key).await?;
-
-        // Delete the associated content file
-        let _ = remove_file(self.0.content_path(key)).await;
-
+        // Acquire an exclusive lock on the response and content files
+        // This will truncate the files and therefore any attempt to deserialize an
+        // empty response file will fail and be treated as if the cache entry is not
+        // present
+        let _response_lock = self.0.lock_exclusive(self.0.response_path(key)).await?;
+        let _content_lock = self.0.lock_exclusive(self.0.content_path(key)).await?;
         Ok(())
     }
 
@@ -321,23 +295,53 @@ impl DefaultCacheStorageInner {
     /// Reads a response from storage for the given key.
     ///
     /// This method will block if the response file is exclusively locked.
-    async fn read_response(&self, key: &str) -> Result<Option<CachedResponse>> {
-        // Acquire a shared lock on the response file
-        let mut response = match self.lock_response_shared(key).await? {
+    ///
+    /// Returns `Ok(None)` if the cache entry doesn't exist or is otherwise
+    /// invalid.
+    ///
+    /// Returns both the the cached response and body.
+    async fn read_response<B: Body + Send>(
+        &self,
+        key: &str,
+    ) -> Result<Option<(CachedResponse, CacheBody<B>)>> {
+        // Acquire a shared lock on the response file first
+        let response_path = self.response_path(key);
+        let mut response_lock = match self.lock_shared(&response_path).await? {
             Some(file) => file,
             None => return Ok(None),
         };
 
-        // Decode the cached response
-        Ok(bincode::deserialize_from(&mut response)
-            .inspect_err(|e| {
+        // Acquire a shared lock on the content file next
+        let content_path = self.content_path(key);
+        let content_lock = match self.lock_shared(&content_path).await? {
+            Some(file) => file,
+            None => return Ok(None),
+        };
+
+        // Deserialize the entry
+        let response: CachedResponse = match bincode::deserialize_from(&mut response_lock) {
+            Ok(response) => response,
+            Err(e) => {
                 debug!(
                     "failed to deserialize response file `{path}`: {e} (cache entry will be \
                      ignored)",
-                    path = self.response_path(key).display()
+                    path = response_path.display()
                 );
-            })
-            .ok())
+                return Ok(None);
+            }
+        };
+
+        Ok(Some((
+            response,
+            CacheBody::from_file(content_lock.into())
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to read response body `{path}`",
+                        path = content_path.display()
+                    )
+                })?,
+        )))
     }
 
     /// Writes a response to storage for the given key.
@@ -350,17 +354,36 @@ impl DefaultCacheStorageInner {
         content: Option<TempPath>,
     ) -> Result<()> {
         // Acquire a shared lock on the response file
-        let mut file = self.lock_response_exclusive(key).await?;
+        // This will truncate the response file and invalidate the cache entry should
+        // the remainder of this method fail
+        let mut response_lock = self.lock_exclusive(self.response_path(key)).await?;
 
-        // Encode the response
-        bincode::serialize_into(&mut file, &response)
-            .with_context(|| format!("failed to serialize response data for cache key `{key}`"))
-            .map(|_| ())?;
-
+        // Persist the content file before writing the response file
         if let Some(content) = content {
             let content_path = self.content_path(key);
-            fs::create_dir_all(content_path.parent().expect("should have parent"))
-                .context("failed to create content directory")?;
+
+            // Acquire and immediately drop the lock on the response file.
+            //
+            // A shared lock on the content file is only ever acquired when there is a
+            // shared lock on the response file.
+            //
+            // As we have already obtained an exclusive lock on the response file above,
+            // this is here to wait for any current readers of the response file
+            // to release their shared locks.
+            //
+            // We must unlock the file _before_ persisting as on Windows we cannot persist
+            // to a file with open file handles.
+            let _ = self.lock_exclusive(&content_path).await?;
+
+            // Create the parent directory before persisting in case it doesn't exist
+            if let Some(parent) = content_path.parent() {
+                fs::create_dir_all(parent).with_context(|| {
+                    format!(
+                        "failed to create directory `{parent}`",
+                        parent = parent.display()
+                    )
+                })?;
+            }
 
             // Atomically persist the temporary content file into the content location
             content.persist(&content_path).with_context(|| {
@@ -371,17 +394,20 @@ impl DefaultCacheStorageInner {
             })?;
         }
 
-        Ok(())
+        // Encode the response file; if this succeeds, the cache entry is now valid
+        bincode::serialize_into(&mut response_lock, &response)
+            .with_context(|| format!("failed to serialize response data for cache key `{key}`"))
+            .map(|_| ())
     }
 
-    /// Locks a response file for shared access.
+    /// Locks a file for shared access.
     ///
     /// Returns `Ok(None)` if the file does not exist.
-    async fn lock_response_shared(&self, key: &str) -> Result<Option<File>> {
-        let path = self.response_path(key);
+    async fn lock_shared(&self, path: impl AsRef<Path>) -> Result<Option<File>> {
+        let path = path.as_ref();
         match fs::OpenOptions::new()
             .read(true)
-            .open(&path)
+            .open(path)
             .map(Some)
             .or_else(|e| {
                 if e.kind() == io::ErrorKind::NotFound {
@@ -390,36 +416,41 @@ impl DefaultCacheStorageInner {
                     Err(e)
                 }
             })
-            .with_context(|| {
-                format!(
-                    "failed to open response file `{path}`",
-                    path = path.display()
-                )
-            })? {
+            .with_context(|| format!("failed to open file `{path}`", path = path.display()))?
+        {
             Some(file) => {
+                let path = path.to_path_buf();
                 match runtime::unwrap_task_output(
                     runtime::spawn_blocking(move || {
-                        file.lock_shared()
-                            .context("failed to acquire shared lock on response file")?;
+                        tracing::debug!(
+                            "attempting to acquire shared lock on file `{path}`",
+                            path = path.display()
+                        );
+                        file.lock_shared().with_context(|| {
+                            format!(
+                                "failed to acquire shared lock on file `{path}`",
+                                path = path.display()
+                            )
+                        })?;
                         Ok(file)
                     })
                     .await,
                 ) {
                     Some(res) => res.map(Some),
-                    None => bail!("failed to wait for file lock"),
+                    None => bail!("failed to acquire file lock"),
                 }
             }
             None => Ok(None),
         }
     }
 
-    /// Locks a response file for exclusive access.
+    /// Locks a file for exclusive access.
     ///
     /// If the file does not exist, it is created.
     ///
     /// The file is intentionally truncated upon lock acquisition.
-    async fn lock_response_exclusive(&self, key: &str) -> Result<File> {
-        let path = self.response_path(key);
+    async fn lock_exclusive(&self, path: impl AsRef<Path>) -> Result<File> {
+        let path = path.as_ref();
         let dir = path.parent().expect("should have parent directory");
         fs::create_dir_all(dir)
             .with_context(|| format!("failed to create directory `{dir}`", dir = dir.display()))?;
@@ -437,17 +468,23 @@ impl DefaultCacheStorageInner {
             options.mode(0o600);
         }
 
-        let file = options.open(&path).with_context(|| {
-            format!(
-                "failed to create response file `{path}`",
-                path = path.display()
-            )
-        })?;
+        let file = options
+            .open(path)
+            .with_context(|| format!("failed to create file `{path}`", path = path.display()))?;
 
+        let file_path = path.to_path_buf();
         let file = match runtime::unwrap_task_output(
             runtime::spawn_blocking(move || {
-                file.lock()
-                    .context("failed to acquire exclusive lock on response file")?;
+                tracing::debug!(
+                    "attempting to acquire exclusive lock on file `{path}`",
+                    path = file_path.display()
+                );
+                file.lock().with_context(|| {
+                    format!(
+                        "failed to acquire exclusive lock on file `{path}`",
+                        path = file_path.display()
+                    )
+                })?;
                 anyhow::Ok(file)
             })
             .await,
@@ -456,12 +493,8 @@ impl DefaultCacheStorageInner {
             None => bail!("failed to wait for file lock"),
         };
 
-        file.set_len(0).with_context(|| {
-            format!(
-                "failed to truncate response file `{path}`",
-                path = path.display()
-            )
-        })?;
+        file.set_len(0)
+            .with_context(|| format!("failed to truncate file `{path}`", path = path.display()))?;
 
         Ok(file)
     }
@@ -494,6 +527,7 @@ mod test {
     async fn cache_hit() {
         const KEY: &str = "key";
         const BODY: &str = "hello world";
+        const MODIFIED_BODY: &str = "hello world!!!!";
         const HEADER_NAME: &str = "foo";
         const HEADER_VALUE: &str = "bar";
 
@@ -561,6 +595,57 @@ mod test {
             .unwrap()
             .unwrap();
         assert_eq!(data, BODY);
+
+        // Create an "updated" response and put it into the cache with a different body
+        let response = Response::builder()
+            .header(HEADER_NAME, HEADER_VALUE)
+            .body(MODIFIED_BODY.to_string())
+            .unwrap();
+        let policy = CachePolicy::new(&request, &response);
+
+        let (parts, body) = response.into_parts();
+        let resp = storage
+            .store(KEY.into(), parts, body, policy)
+            .await
+            .unwrap();
+
+        // Read the whole body so that the "upstream" response is fully written to the
+        // cache
+        let mut stream = BodyDataStream::new(resp.into_body());
+        assert_eq!(
+            stream
+                .next()
+                .await
+                .unwrap()
+                .unwrap()
+                .as_array::<{ MODIFIED_BODY.len() }>()
+                .unwrap(),
+            MODIFIED_BODY.as_bytes()
+        );
+        assert!(stream.next().await.is_none());
+
+        // Lookup the cache entry (should exist with the header)
+        let cached = storage.get::<String>(KEY).await.unwrap().unwrap();
+        assert_eq!(
+            cached
+                .response
+                .headers()
+                .get(HEADER_NAME)
+                .map(|v| v.to_str().unwrap()),
+            Some(HEADER_VALUE)
+        );
+
+        // Read the cached response (should be modified)
+        let data = BodyDataStream::new(cached.response.into_body())
+            .next()
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(data, MODIFIED_BODY);
+
+        // Delete the key and ensure it no longer exists
+        storage.delete(KEY).await.unwrap();
+        assert!(storage.get::<String>(KEY).await.unwrap().is_none());
 
         // Delete the key and ensure it no longer exists
         storage.delete(KEY).await.unwrap();


### PR DESCRIPTION
This PR removes content digesting of response bodies.

Deduplication of stored response bodies was a niche requirement and not worth the cost of calculating digests or the added garbage in the cache when response bodies change.

The storage content directory is now based of cache key and not content digest and therefore a cached body file will be replaced when modified upstream.